### PR TITLE
Added check to ensure pacbed_pattern is allocated before writing to it

### DIFF
--- a/Source/s_absorptive_stem.f90
+++ b/Source/s_absorptive_stem.f90
@@ -266,7 +266,7 @@ subroutine absorptive_stem(STEM,ionization,PACBED)
         call ifft2(nopiy, nopix, psi, nopiy, transf_absorptive(:,:,i), nopiy)
     enddo
     
-	pacbed_pattern = 0
+	if(pacbed) pacbed_pattern = 0
 #ifdef GPU
     if(pacbed) pacbed_pattern_d = 0
 	prop_d = prop


### PR DESCRIPTION
This code follows the setup of the other checks in your code that pacbed is True, before writing to the pacbed_pattern array. It ensures that a "writing to unallocated pointer" error does not occur.